### PR TITLE
ci: shift dependency-update schedule off the top of the hour

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -31,8 +31,11 @@ name: Update Python Dependencies
 
 on:
   schedule:
-    # Run weekly on Monday at 15:00 UTC (9 AM MDT / 8 AM MST)
-    - cron: '0 15 * * 1'
+    # Run weekly on Monday at 14:37 UTC (8:37 AM MDT / 7:37 AM MST).
+    # Off the top of the hour deliberately: GitHub throttles schedule
+    # triggers hardest at round-hour slots (e.g. :00), so an odd minute
+    # lands in a less-contended queue and starts closer to the nominal time.
+    - cron: '37 14 * * 1'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

GitHub Actions `schedule` triggers are best-effort, not a hard runtime — and the contention is worst at round-hour slots (e.g. `:00`). The dependency-update workflow's `0 15 * * 1` cron has consistently started **1–5 hours late** as a result.

Run-history evidence (all `schedule`-triggered, nominal 15:00 UTC):

| Date | Actual start (UTC) | Delay |
|------|--------------------|-------|
| 2026-06-15 | 19:05 | +4h 05m |
| 2026-06-08 | 17:58 | +2h 58m |
| 2026-06-01 | 19:56 | +4h 56m |
| 2026-05-25 | 17:09 | +2h 09m |
| 2026-05-04 | 16:50 | +1h 50m |

## Change

Move the cron to `37 14 * * 1` (14:37 UTC = 8:37 AM MDT / 7:37 AM MST) — an odd minute, off the top of the hour, which lands in a less-contended queue and should start closer to the nominal time.

Takes effect once merged to `main`; first run under the new schedule is the following Monday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)