### PR TITLE
docs(data): CAS retry-primitive pointer + multi-record backend-choice guidance

### DIFF
--- a/docs/packages/data/api-reference.md
+++ b/docs/packages/data/api-reference.md
@@ -129,9 +129,37 @@ try:
     db.update("k", Record({"v": 2}, id="k"), expected_version=token)
 except ConcurrencyError as e:
     # Someone else wrote "k" since we read the token; e.context has
-    # {"id", "expected_version", "actual_version"}. Re-read and retry.
+    # {"id", "expected_version", "actual_version"}. Re-read and retry —
+    # the RetryExecutor form below automates exactly this loop.
     ...
 ```
+
+Rather than hand-roll the re-read → recompute → conditional-write loop, wrap the
+whole read-modify-write in a callable and drive it with the shipped
+`RetryExecutor` (`dataknobs_common.retry`), retrying on `ConcurrencyError`. Each
+attempt re-reads the token inside the callable, so every try sees fresh state:
+
+```python
+from dataknobs_common.retry import RetryExecutor, RetryConfig
+from dataknobs_data import ConcurrencyError, Record
+
+async def bump_counter() -> None:
+    token = await db.get_version("k")                 # re-read every attempt
+    current = await db.read("k")
+    await db.update(
+        "k", Record({"v": current.get_value("v") + 1}, id="k"),
+        expected_version=token,
+    )
+
+await RetryExecutor(
+    RetryConfig(retry_on_exceptions=[ConcurrencyError], max_attempts=5)
+).execute(bump_counter)
+```
+
+The retry *policy* — how many attempts, the backoff, when to give up — is yours,
+expressed through `RetryConfig` (`max_attempts`, `initial_delay`,
+`backoff_strategy`, …). `RetryExecutor.execute` runs sync or async callables, so
+the same shape works from either context.
 
 Semantics:
 

--- a/docs/packages/data/transactions.md
+++ b/docs/packages/data/transactions.md
@@ -40,6 +40,19 @@ earlier batches have already been applied and stay applied. Open the transaction
 with the default `policy="strict"` there to fail closed rather than assume an
 atomicity the backend cannot deliver.
 
+**Choosing a backend for multi-record atomicity.** The mutation shapes that make
+this boundary matter are the multi-record ones a versioned or archival store
+performs: **replace** (delete the old records, create the new), **reconcile**
+(upsert what changed, delete what was removed), and **prune-and-write /
+retention** (delete the oldest N, create the newest). These are all-or-nothing
+**only** on a transactional backend (`sqlite`, `postgres`, `duckdb`). On a
+non-transactional backend (`memory`, `file`, `s3`, `elasticsearch`) they are
+best-effort — pick one of three options: open the transaction with
+`policy="strict"` to fail closed rather than half-apply; rely on per-record
+`expected_version` CAS for single-record safety, which holds on *every* backend;
+or move the store to a transactional backend when the whole multi-record
+mutation must commit atomically.
+
 Branch on **`is_atomic`** to know whether a commit is all-or-nothing:
 
 ```python
@@ -67,8 +80,9 @@ boundaries would interleave. Serialize writes to a single-connection instance
 yourself if they can overlap. Connection-scoped isolation / read-your-writes is
 not provided — the public API exposes no connection-scoped transaction beyond
 this buffered form. For a read-modify-write invariant use optimistic
-concurrency (`update` / `upsert` with `expected_version`) or serialize the
-conflicting work yourself.
+concurrency (`update` / `upsert` with `expected_version`; see the CAS-retry
+example in the [API reference](api-reference.md#optimistic-concurrency-conditional-writes))
+or serialize the conflicting work yourself.
 
 ## `supports_transactions()`
 

--- a/packages/data/docs/API_REFERENCE.md
+++ b/packages/data/docs/API_REFERENCE.md
@@ -161,9 +161,37 @@ try:
     db.update("k", Record({"v": 2}, id="k"), expected_version=token)
 except ConcurrencyError as e:
     # Someone else wrote "k" since we read the token; e.context has
-    # {"id", "expected_version", "actual_version"}. Re-read and retry.
+    # {"id", "expected_version", "actual_version"}. Re-read and retry —
+    # the RetryExecutor form below automates exactly this loop.
     ...
 ```
+
+Rather than hand-roll the re-read → recompute → conditional-write loop, wrap the
+whole read-modify-write in a callable and drive it with the shipped
+`RetryExecutor` (`dataknobs_common.retry`), retrying on `ConcurrencyError`. Each
+attempt re-reads the token inside the callable, so every try sees fresh state:
+
+```python
+from dataknobs_common.retry import RetryExecutor, RetryConfig
+from dataknobs_data import ConcurrencyError, Record
+
+async def bump_counter() -> None:
+    token = await db.get_version("k")                 # re-read every attempt
+    current = await db.read("k")
+    await db.update(
+        "k", Record({"v": current.get_value("v") + 1}, id="k"),
+        expected_version=token,
+    )
+
+await RetryExecutor(
+    RetryConfig(retry_on_exceptions=[ConcurrencyError], max_attempts=5)
+).execute(bump_counter)
+```
+
+The retry *policy* — how many attempts, the backoff, when to give up — is yours,
+expressed through `RetryConfig` (`max_attempts`, `initial_delay`,
+`backoff_strategy`, …). `RetryExecutor.execute` runs sync or async callables, so
+the same shape works from either context.
 
 Semantics:
 

--- a/packages/data/docs/TRANSACTIONS.md
+++ b/packages/data/docs/TRANSACTIONS.md
@@ -40,6 +40,19 @@ earlier batches have already been applied and stay applied. Open the transaction
 with the default `policy="strict"` there to fail closed rather than assume an
 atomicity the backend cannot deliver.
 
+**Choosing a backend for multi-record atomicity.** The mutation shapes that make
+this boundary matter are the multi-record ones a versioned or archival store
+performs: **replace** (delete the old records, create the new), **reconcile**
+(upsert what changed, delete what was removed), and **prune-and-write /
+retention** (delete the oldest N, create the newest). These are all-or-nothing
+**only** on a transactional backend (`sqlite`, `postgres`, `duckdb`). On a
+non-transactional backend (`memory`, `file`, `s3`, `elasticsearch`) they are
+best-effort — pick one of three options: open the transaction with
+`policy="strict"` to fail closed rather than half-apply; rely on per-record
+`expected_version` CAS for single-record safety, which holds on *every* backend;
+or move the store to a transactional backend when the whole multi-record
+mutation must commit atomically.
+
 Branch on **`is_atomic`** to know whether a commit is all-or-nothing:
 
 ```python
@@ -67,8 +80,9 @@ boundaries would interleave. Serialize writes to a single-connection instance
 yourself if they can overlap. Connection-scoped isolation / read-your-writes is
 not provided — the public API exposes no connection-scoped transaction beyond
 this buffered form. For a read-modify-write invariant use optimistic
-concurrency (`update` / `upsert` with `expected_version`) or serialize the
-conflicting work yourself.
+concurrency (`update` / `upsert` with `expected_version`; see the CAS-retry
+example in the [API reference](API_REFERENCE.md#optimistic-concurrency-conditional-writes))
+or serialize the conflicting work yourself.
 
 ## `supports_transactions()`
 


### PR DESCRIPTION
## What

Two documentation-completeness fixes on the `dataknobs-data` optimistic-concurrency + transactions surface. Doc-only; no code or behavior change.

**Part A — the CAS worked example now points at the shipped retry loop.** The compare-and-set example in the API reference ended at "re-read and retry" with a bare `...`, leaving the consumer to hand-roll a re-read → recompute → conditional-write loop — even though `dataknobs_common.retry.RetryExecutor` (`RetryConfig.retry_on_exceptions`) is exactly that loop and `ConcurrencyError` exactly the typed exception. Added a runnable CAS-retry example in the **async** `RetryExecutor.execute` form: the read-modify-write is wrapped in a callable so each attempt re-reads the token, and the retry *policy* (attempts, backoff, give-up) stays the consumer's via `RetryConfig`.

**Part B — the non-transactional multi-record boundary now has backend-choice guidance.** The transactions guide documented the non-transactional multi-kind commit boundary but did not connect it to the mutation shapes that surface it. Added a paragraph naming the **replace** / **reconcile** / **prune-and-write (retention)** shapes: all-or-nothing only on a transactional backend (`sqlite`/`postgres`/`duckdb`); on a non-transactional backend, use `policy="strict"` to fail closed, per-record `expected_version` CAS for single-record safety (holds on every backend), or move the store to a transactional backend. Added a cross-reference from the transactions guide's read-modify-write mention to the CAS-retry example.

## Verification

- The CAS-retry example was run end-to-end against `AsyncMemoryDatabase` before it was written into the docs: a stale-token `ConcurrencyError` drives exactly one retry, final value correct.
- Every referenced symbol resolves against shipped code (`RetryExecutor`/`RetryConfig.retry_on_exceptions`, `ConcurrencyError`, `is_atomic`, `policy="strict"`).
- Both dual-doc trees updated in sync (`packages/data/docs/` + `docs/packages/data/`); the transactions pair differs only by the intended intra-doc link filename.
- `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)