### PR TITLE
docs(data): resync api-reference site mirror; fix FieldType import

### DIFF
--- a/docs/packages/data/api-reference.md
+++ b/docs/packages/data/api-reference.md
@@ -29,23 +29,54 @@ The DataKnobs Data Package provides a unified data abstraction layer with suppor
 The `Database` class provides async database operations, while `SyncDatabase` provides synchronous operations.
 
 ```python
-from dataknobs_data import Database, SyncDatabase
+from dataknobs_data import AsyncDatabaseFactory, DatabaseFactory, Record
 
 # Async usage
 async def main():
-    db = await Database.create("memory")  # Auto-connects
-    record = Record({"name": "Alice", "age": 30})
-    id = await db.create(record)
-    retrieved = await db.read(id)
+    factory = AsyncDatabaseFactory()
+    db = factory.create(backend="memory")
+    await db.connect()
+
+    record = Record(data={"name": "Alice", "age": 30})
+    record_id = await db.create(record)
+    retrieved = await db.read(record_id)
     await db.close()
 
 # Sync usage
-db = SyncDatabase.create("memory")  # Auto-connects
-record = Record({"name": "Bob", "age": 25})
-id = db.create(record)
-retrieved = db.read(id)
+factory = DatabaseFactory()
+db = factory.create(backend="memory")
+db.connect()
+
+record = Record(data={"name": "Bob", "age": 25})
+record_id = db.create(record)
+retrieved = db.read(record_id)
 db.close()
 ```
+
+#### Typed configuration (advanced)
+
+Every backend is constructed through a typed `<Backend>DatabaseConfig`
+frozen dataclass (a `dataknobs_common.structured_config.StructuredConfig`
+subclass). The factory and the dict-construction shapes shown above
+continue to work unchanged — the dict keys are projected onto the typed
+config. For programmatic construction you can also build the typed config
+directly and pass it in; after construction, `db.config` is that typed
+object (read fields as attributes, e.g. `db.config.table`, not
+`db.config["table"]`):
+
+```python
+from dataknobs_data.backends.config import SyncSQLiteDatabaseConfig
+from dataknobs_data.backends.sqlite import SyncSQLiteDatabase
+
+cfg = SyncSQLiteDatabaseConfig(path="data.db", table="records")
+db = SyncSQLiteDatabase.from_config(cfg)   # or SyncSQLiteDatabase(cfg)
+assert db.config.table == "records"
+```
+
+Each backend exposes its config class via `db.CONFIG_CLS`. Mixing a typed
+`config=` with loose keyword arguments raises `TypeError`. The Postgres
+sync and async backends share one `PostgresDatabaseConfig`; the file
+backends share one `FileDatabaseConfig`.
 
 #### Database Methods
 
@@ -55,7 +86,7 @@ db.close()
 - `update(id: str, record: Record, *, expected_version: str | None = None) -> bool`: Update an existing record; with `expected_version`, a compare-and-set that raises `ConcurrencyError` on a stale token
 - `delete(id: str, *, expected_version: str | None = None) -> bool`: Delete a record; with `expected_version`, a compare-and-set that raises `ConcurrencyError` on a stale token (a missing record returns `False`)
 - `exists(id: str) -> bool`: Check if a record exists
-- `upsert(id_or_record: str | Record, record: Record | None = None, *, expected_version: str | None = None) -> str`: Update or insert a record (enhanced to accept just a Record); with `expected_version`, a compare-and-set that never inserts
+- `upsert(id: str, record: Record, *, expected_version: str | None = None) -> str`: Update or insert a record; with `expected_version`, a compare-and-set that never inserts
 - `search(query: Query) -> List[Record]`: Search for records
 - `count(query: Query | None) -> int`: Count matching records
 - `clear() -> int`: Delete all records
@@ -82,18 +113,18 @@ except DuplicateRecordError as e:
 `DuplicateRecordError` subclasses both the data-layer `ConcurrencyError` and
 `ValueError`, so code that previously caught `ValueError` on a duplicate id
 keeps working. It carries the colliding id on `.id` and in `context={"id": ...}`.
-To overwrite when the id may already exist, use `upsert()` instead.
+
+To overwrite when the id may already exist, use `upsert()` instead of `create()`.
 
 Backend notes:
 
 - **memory, file, SQLite, DuckDB, Postgres, Elasticsearch** enforce the insert
   through their native uniqueness/constraint mechanism (in-lock check, primary
   key, or `op_type=create`).
-- **S3** enforces it with a conditional PUT (`If-None-Match`); the atomic
+- **S3** enforces it with a conditional PUT (`If-None-Match`). The atomic
   guarantee holds against any S3 implementation that honors conditional writes
-  (real AWS S3, recent LocalStack) — both a pre-existing key (412) and a
-  concurrent conditional-write race (409) fail closed — and degrades to
-  last-writer-wins on stores that ignore the header.
+  (real AWS S3, recent LocalStack); stores that ignore the header degrade to
+  last-writer-wins.
 - **`create_batch()` fails closed uniformly across every backend**, matching
   single `create()`: a colliding id — against an existing record or a duplicate
   within the same batch — raises `DuplicateRecordError`, and `record.id` is
@@ -101,7 +132,8 @@ Backend notes:
   DuckDB, PostgreSQL) the batch is atomic — a collision rolls back the whole
   INSERT (nothing written); on Elasticsearch the bulk API is per-item, so — like
   a `create()` loop — non-colliding rows may be written before the conflict is
-  raised. The *streaming* INSERT path fails closed on every backend too.
+  raised. The *streaming* INSERT path fails closed on every backend too — see the
+  batch-processing / migration guides.
 - **`upsert_batch(records)`** is the batch sibling of `create_batch`, with
   upsert (insert-or-overwrite) semantics: it honors a caller-supplied
   `record.id` (minting one only when absent), **overwrites** a colliding id
@@ -173,23 +205,26 @@ Semantics:
   matches; a mismatch raises `ConcurrencyError`, and a missing record returns
   `False` (an absent id never conflicts).
 - **`upsert()` with a token never inserts.** A missing record is itself a
-  conflict and raises `ConcurrencyError`; a mismatched token also raises.
+  conflict (its current version is `None`) and raises `ConcurrencyError`; an
+  existing record with a mismatched token also raises.
 
 Token source and atomicity by backend:
 
-- **memory** — a per-instance monotonic sequence under the instance lock;
-  ABA-safe on every path, including delete→recreate at the same id.
-- **PostgreSQL** — the row's `xmin`, enforced server-side with
+- **memory** — a per-instance monotonic sequence value; the compare-and-set runs
+  under the instance lock. ABA-safe on every path, including delete→recreate at
+  the same id (the token is never reused).
+- **PostgreSQL** — the row's `xmin`; enforced server-side with
   `WHERE id = … AND xmin = …` (ABA-safe, atomic across connections).
-- **Elasticsearch** — the document's `_seq_no`/`_primary_term`, enforced
+- **Elasticsearch** — the document's `_seq_no`/`_primary_term`; enforced
   server-side with `if_seq_no`/`if_primary_term` (ABA-safe).
-- **S3** — the object's `ETag`, enforced with a conditional PUT/DELETE
+- **S3** — the object's `ETag`; enforced with a conditional PUT/DELETE
   (`If-Match`) against any store that honors it (real AWS S3, recent LocalStack).
-- **file, SQLite, DuckDB** — a deterministic content hash of the stored record;
-  the check is serialized within a single connection/instance. A content hash is
-  subject to the classic **ABA** limitation (an A→B→A cycle yields the original
-  token) and is not hardened across separate processes/connections — use a
-  native-token backend when either matters.
+- **file, SQLite, DuckDB** — a deterministic content hash of the stored record.
+  The check is serialized within a single connection/instance. Two caveats: a
+  content hash is subject to the classic **ABA** limitation (an A→B→A cycle
+  yields the original token, so a stale write in that exact scenario is not
+  detected), and the compare-and-set is not hardened across separate
+  processes/connections. Use a native-token backend when either matters.
 
 #### Capability advertisement
 
@@ -212,7 +247,8 @@ require_capability(db, Capability.CONDITIONAL_WRITE)
 
 The advertisement is uniform because every backend enforces the contract; the
 ABA nuance of the content-hash backends (above) is documented rather than
-encoded as a separate capability.
+encoded as a separate capability. Select a native-token backend by reading the
+token-source matrix above when ABA-safety matters.
 
 ### Records
 
@@ -234,6 +270,14 @@ record = Record(
 name = record.get_value("name")
 age = record.get_value("age", default=0)
 
+# Dot-notation for nested fields and metadata
+record2 = Record(
+    data={"config": {"timeout": 30}},
+    metadata={"tenant_id": "T-1"}
+)
+record2.get_value("config.timeout")          # 30
+record2.get_value("metadata.tenant_id")      # "T-1"
+
 # Set values
 record.set_value("email", "alice@example.com")
 
@@ -245,42 +289,10 @@ if record.has_field("email"):
 data_dict = record.to_dict()
 ```
 
-### Enhanced Upsert (New)
-
-The `upsert` method now supports a more intuitive API that can accept just a Record object, leveraging the Record's built-in ID management:
-
-```python
-from dataknobs_data import Database, Record
-
-async def example():
-    db = await Database.create("memory")
-    
-    # Traditional usage (still supported)
-    record = Record({"name": "Alice", "age": 30})
-    await db.upsert("user-123", record)
-    
-    # New: Upsert with record that has an ID field
-    record_with_id = Record({"id": "user-456", "name": "Bob", "age": 25})
-    await db.upsert(record_with_id)  # Uses record's ID
-    
-    # New: Auto-generate ID if record has no ID
-    record_no_id = Record({"name": "Charlie", "age": 35})
-    generated_id = await db.upsert(record_no_id)  # Returns generated UUID
-    print(f"Generated ID: {generated_id}")
-    
-    # ID Priority (when using new signature):
-    # 1. record.storage_id (if set)
-    # 2. record.id (from 'id' field in data)
-    # 3. Generated UUID
-```
-
-This enhancement is available across all database backends:
-- Memory (AsyncMemoryDatabase, SyncMemoryDatabase)
-- File (AsyncFileDatabase, SyncFileDatabase)
-- SQLite (AsyncSQLiteDatabase, SyncSQLiteDatabase)
-- PostgreSQL (AsyncPostgresDatabase, SyncPostgresDatabase)
-- Elasticsearch (AsyncElasticsearchDatabase, SyncElasticsearchDatabase)
-- S3 (AsyncS3Database)
+> **Note:** Dots in field names are always interpreted as path separators.
+> JSON keys that literally contain a dot (e.g. `"my.field"`) cannot be
+> accessed via `get_value()` or filtered on.  This convention is consistent
+> across `Record.get_value()` and the Query/Filter system on all backends.
 
 ### Query
 
@@ -300,6 +312,11 @@ query = (Query()
     .sort("age", SortOrder.DESC)
     .limit(10)
     .offset(20))
+
+# Dot-notation for nested and metadata fields (works on all backends)
+query = (Query()
+    .filter("metadata.tenant_id", Operator.EQ, "T-1")
+    .filter("config.timeout", Operator.GT, 30))
 
 # Available operators
 # Operator.EQ - equals
@@ -326,7 +343,7 @@ from dataknobs_data import StreamConfig, StreamResult
 # Configure streaming
 config = StreamConfig(
     batch_size=100,
-    buffer_size=1000,
+    prefetch=2,
     on_error=lambda e, r: print(f"Error: {e}")
 )
 
@@ -341,6 +358,13 @@ print(f"Successful: {result.successful}")
 print(f"Failed: {result.failed}")
 ```
 
+`StreamConfig` is a frozen `StructuredConfig` (from `dataknobs-common`):
+it loads from a plain dict via `StreamConfig.from_dict({"batch_size":
+100})` and is immutable — build a modified copy with
+`dataclasses.replace(config, batch_size=200)` rather than assigning to a
+field. Its `batch_size > 0` / `prefetch >= 0` / positive-`timeout`
+validation fires on both direct construction and `from_dict`.
+
 ## Validation Module
 
 The validation module (`dataknobs_data.validation`) provides schema-based validation with constraints and type coercion.
@@ -350,7 +374,8 @@ The validation module (`dataknobs_data.validation`) provides schema-based valida
 Define validation schemas for your data.
 
 ```python
-from dataknobs_data.validation import Schema, FieldType
+from dataknobs_data import FieldType
+from dataknobs_data.validation import Schema
 from dataknobs_data.validation.constraints import Required, Range, Length, Pattern
 
 # Create schema
@@ -413,7 +438,7 @@ Custom(validate_email, "Invalid email format")
 
 # Composite constraints
 All([Required(), Range(min=0)])  # All must pass
-Any([Pattern(r"^\d+$"), Pattern(r"^[A-Z]+$")])  # At least one must pass
+AnyOf([Pattern(r"^\d+$"), Pattern(r"^[A-Z]+$")])  # At least one must pass
 
 # Constraint composition with operators
 constraint = Required() & Range(min=0, max=100)  # AND
@@ -425,7 +450,8 @@ constraint = Length(min=10) | Pattern(r"^\d{5}$")  # OR
 Type coercion for automatic type conversion:
 
 ```python
-from dataknobs_data.validation import Coercer, FieldType
+from dataknobs_data import FieldType
+from dataknobs_data.validation import Coercer
 
 coercer = Coercer()
 
@@ -508,9 +534,10 @@ original = migration.apply(migrated, reverse=True)
 ### Migrator
 
 `Migrator` is a stateless orchestrator; the source and target are passed per
-call. See the [Migration guide](migration.md) for the streaming methods
-(`migrate_stream` / `migrate_parallel` / `migrate_async`) and the full
-conflict-policy API.
+call. See the [Migration guide](migration.md) for the
+streaming write path (`StreamConfig` / `StreamResult`) and the full
+conflict-policy API; `migrate_stream` / `migrate_parallel` / `migrate_async`
+are the streaming siblings of `migrate`.
 
 ```python
 from dataknobs_data.migration import Migrator
@@ -541,58 +568,238 @@ progress = migrator.migrate(source_db, target_db, on_conflict="upsert")
 
 ## Backends
 
+The DataKnobs Data Package supports multiple storage backends to fit different use cases. Choose a backend based on your requirements for persistence, performance, scalability, and features.
+
+### Backend Comparison
+
+| Backend | Persistent | Vector Support | Best For | Installation |
+|---------|-----------|----------------|----------|--------------|
+| **Memory** | No | No | Testing, caching, temporary data | Built-in |
+| **File** | Yes | No | Simple storage, JSON/CSV/Parquet files | Built-in |
+| **SQLite** | Yes | Yes (Python) | Embedded database, single-user apps | Built-in |
+| **DuckDB** | Yes | No | Analytics, OLAP, large datasets | `pip install duckdb` |
+| **PostgreSQL** | Yes | Yes (pgvector) | Production, multi-user, ACID | `pip install dataknobs-data[postgres]` |
+| **Elasticsearch** | Yes | Yes (native KNN) | Full-text search, large-scale search | `pip install dataknobs-data[elasticsearch]` |
+| **S3** | Yes | No | Cloud storage, distributed systems | `pip install dataknobs-data[s3]` |
+
+### Choosing the Right Backend
+
+**For development and testing:**
+- Use **Memory** for unit tests and prototyping
+
+**For local file storage:**
+- Use **File** for simple JSON/CSV data persistence
+- Use **SQLite** for transactional workloads with relationships
+- Use **DuckDB** for analytical queries and large datasets
+
+**SQLite vs DuckDB:**
+- Choose **SQLite** when you need:
+  - ACID transactions and concurrent writes
+  - Vector similarity search
+  - Standard SQL database operations (OLTP)
+  - Maximum compatibility
+
+- Choose **DuckDB** when you need:
+  - Fast analytical queries (aggregations, joins, window functions)
+  - Columnar storage efficiency
+  - Reading large datasets (10M+ rows)
+  - Data warehousing and OLAP workloads
+
+**For production:**
+- Use **PostgreSQL** for multi-user applications requiring strong consistency
+- Use **Elasticsearch** for full-text search and complex queries
+- Use **S3** for cloud-native, distributed storage
+
 ### Memory Backend
 
 In-memory storage for testing and development:
 
 ```python
-db = await Database.create("memory")
+from dataknobs_data import DatabaseFactory
+
+# Create and connect
+factory = DatabaseFactory()
+db = factory.create(backend="memory")
+db.connect()
+
+# Use the database
+record = Record(data={"name": "Alice", "age": 30})
+record_id = db.create(record)
+
+# Close when done
+db.close()
+```
+
+Or using the async factory:
+
+```python
+from dataknobs_data import AsyncDatabaseFactory
+
+factory = AsyncDatabaseFactory()
+db = factory.create(backend="memory")
+await db.connect()
+
+# Use database
+record_id = await db.create(record)
+
+await db.close()
 ```
 
 ### File Backend
 
-JSON file-based storage:
+File-based storage supporting JSON, CSV, and Parquet formats:
 
 ```python
-db = await Database.create("file", {
-    "path": "/data/records.json",
-    "pretty": True,
-    "backup": True
-})
+from dataknobs_data import DatabaseFactory
+
+factory = DatabaseFactory()
+
+# JSON format (default)
+db = factory.create(
+    backend="file",
+    path="/data/records.json",
+    format="json",
+    pretty=True,
+    backup=True
+)
+db.connect()
+
+# CSV format
+db = factory.create(
+    backend="file",
+    path="/data/records.csv",
+    format="csv"
+)
+db.connect()
+
+# Parquet format
+db = factory.create(
+    backend="file",
+    path="/data/records.parquet",
+    format="parquet",
+    compression="gzip"
+)
+db.connect()
 ```
 
 ### SQLite Backend
 
-SQLite database storage with full SQL capabilities:
+SQLite database storage with optional vector support:
 
 ```python
-# In-memory database
-db = await Database.create("sqlite", {
-    "path": ":memory:"
-})
+from dataknobs_data import DatabaseFactory
 
-# File-based database
-db = await Database.create("sqlite", {
-    "path": "/data/app.db",
-    "journal_mode": "WAL",  # Better concurrency
-    "synchronous": "NORMAL"  # Balance safety/speed
-})
+factory = DatabaseFactory()
+
+# Basic SQLite database
+db = factory.create(
+    backend="sqlite",
+    path="/data/database.db",
+    table="records"
+)
+db.connect()
+
+# In-memory SQLite database
+db = factory.create(
+    backend="sqlite",
+    path=":memory:"
+)
+db.connect()
+
+# With vector support for similarity search
+db = factory.create(
+    backend="sqlite",
+    path="/data/vector.db",
+    table="records",
+    vector_enabled=True,
+    vector_metric="cosine"  # Options: cosine, euclidean, dot_product
+)
+db.connect()
 ```
+
+### DuckDB Backend
+
+DuckDB database backend optimized for analytical workloads with columnar storage:
+
+```python
+from dataknobs_data import DatabaseFactory, AsyncDatabaseFactory
+
+# Sync version
+factory = DatabaseFactory()
+
+# File-based DuckDB database
+db = factory.create(
+    backend="duckdb",
+    path="/data/analytics.duckdb",
+    table="records"
+)
+db.connect()
+
+# In-memory DuckDB database (fast analytics)
+db = factory.create(
+    backend="duckdb",
+    path=":memory:"
+)
+db.connect()
+
+# With custom configuration
+db = factory.create(
+    backend="duckdb",
+    path="/data/analytics.duckdb",
+    table="records",
+    timeout=10.0,
+    read_only=False
+)
+db.connect()
+
+# Async version
+async_factory = AsyncDatabaseFactory()
+db = async_factory.create(
+    backend="duckdb",
+    path="/data/analytics.duckdb"
+)
+await db.connect()
+```
+
+**DuckDB Features:**
+- Optimized for analytical (OLAP) workloads
+- Columnar storage for efficient querying
+- 10-100x faster than SQLite for analytics
+- Supports complex queries with aggregations
+- Both file-based and in-memory modes
+- Ideal for data analysis, reporting, and ETL
 
 ### PostgreSQL Backend
 
 PostgreSQL database storage:
 
 ```python
-db = await Database.create("postgres", {
-    "host": "localhost",
-    "port": 5432,
-    "database": "mydb",
-    "user": "user",
-    "password": "pass",
-    "table": "records",
-    "schema": "public"
-})
+from dataknobs_data import AsyncDatabaseFactory
+
+factory = AsyncDatabaseFactory()
+
+db = factory.create(
+    backend="postgres",
+    host="localhost",
+    port=5432,
+    database="mydb",
+    user="user",
+    password="pass",
+    table="records"
+)
+await db.connect()
+
+# With vector support (requires pgvector extension)
+db = factory.create(
+    backend="postgres",
+    host="localhost",
+    database="mydb",
+    user="user",
+    password="pass",
+    vector_enabled=True,
+    vector_metric="cosine"
+)
+await db.connect()
 ```
 
 ### S3 Backend
@@ -600,13 +807,37 @@ db = await Database.create("postgres", {
 AWS S3 storage:
 
 ```python
-db = await Database.create("s3", {
-    "bucket": "my-bucket",
-    "prefix": "records/",
-    "region": "us-west-2",
-    "aws_access_key_id": "key",
-    "aws_secret_access_key": "secret"
-})
+from dataknobs_data import AsyncDatabaseFactory
+
+factory = AsyncDatabaseFactory()
+
+db = factory.create(
+    backend="s3",
+    bucket="my-bucket",
+    prefix="records/",
+    region="us-west-2",
+    access_key_id="key",
+    secret_access_key="secret"
+)
+await db.connect()
+
+# Using IAM role (no credentials needed)
+db = factory.create(
+    backend="s3",
+    bucket="my-bucket",
+    prefix="records/"
+)
+await db.connect()
+
+# With custom S3-compatible endpoint (e.g., MinIO)
+db = factory.create(
+    backend="s3",
+    bucket="my-bucket",
+    endpoint_url="http://localhost:9000",
+    access_key_id="minioadmin",
+    secret_access_key="minioadmin"
+)
+await db.connect()
 ```
 
 ### Elasticsearch Backend
@@ -614,12 +845,37 @@ db = await Database.create("s3", {
 Elasticsearch storage:
 
 ```python
-db = await Database.create("elasticsearch", {
-    "host": "localhost",
-    "port": 9200,
-    "index": "records",
-    "refresh": True
-})
+from dataknobs_data import AsyncDatabaseFactory
+
+factory = AsyncDatabaseFactory()
+
+# Basic Elasticsearch connection
+db = factory.create(
+    backend="elasticsearch",
+    hosts=["http://localhost:9200"],
+    index="records"
+)
+await db.connect()
+
+# With authentication
+db = factory.create(
+    backend="elasticsearch",
+    hosts=["https://elastic.example.com:9200"],
+    index="records",
+    username="elastic",
+    password="changeme"
+)
+await db.connect()
+
+# With vector support for KNN search
+db = factory.create(
+    backend="elasticsearch",
+    hosts=["http://localhost:9200"],
+    index="records",
+    vector_enabled=True,
+    vector_metric="cosine"
+)
+await db.connect()
 ```
 
 ## Exceptions
@@ -654,15 +910,42 @@ except RecordNotFoundError as e:
 Convenient factory functions for creating databases:
 
 ```python
-from dataknobs_data import database_factory, async_database_factory
+from dataknobs_data import DatabaseFactory, AsyncDatabaseFactory
 
 # Synchronous factory
-db = database_factory("memory")
-db = database_factory("postgres", config)
+factory = DatabaseFactory()
+db = factory.create(backend="memory")
+db.connect()
+
+# With configuration
+db = factory.create(
+    backend="postgres",
+    host="localhost",
+    database="mydb",
+    user="user",
+    password="pass"
+)
+db.connect()
 
 # Asynchronous factory
-db = await async_database_factory("memory")
-db = await async_database_factory("s3", config)
+async_factory = AsyncDatabaseFactory()
+db = async_factory.create(backend="memory")
+await db.connect()
+
+# With configuration
+db = async_factory.create(
+    backend="s3",
+    bucket="my-bucket",
+    prefix="records/"
+)
+await db.connect()
+
+# Using singleton instances
+from dataknobs_data import database_factory, async_database_factory
+
+# These are pre-instantiated factory objects
+db = database_factory.create(backend="memory")
+db = async_database_factory.create(backend="postgres", host="localhost")
 ```
 
 ## Configuration
@@ -670,33 +953,65 @@ db = await async_database_factory("s3", config)
 Many components support configuration through dictionaries or environment variables:
 
 ```python
-# From environment variables (using python-dotenv)
-db = await Database.create("postgres")  # Uses .env file
+import os
+from dataknobs_data import AsyncDatabaseFactory
 
-# From explicit config
+factory = AsyncDatabaseFactory()
+
+# From environment variables (using python-dotenv)
+# Assumes you have .env file with DB_HOST, DB_PORT, etc.
+db = factory.create(
+    backend="postgres",
+    host=os.getenv("DB_HOST", "localhost"),
+    port=int(os.getenv("DB_PORT", 5432)),
+    database=os.getenv("DB_NAME"),
+    user=os.getenv("DB_USER"),
+    password=os.getenv("DB_PASSWORD")
+)
+await db.connect()
+
+# Or use a config dict
 config = {
     "host": os.getenv("DB_HOST"),
     "port": int(os.getenv("DB_PORT", 5432)),
-    "database": os.getenv("DB_NAME")
+    "database": os.getenv("DB_NAME"),
+    "user": os.getenv("DB_USER"),
+    "password": os.getenv("DB_PASSWORD")
 }
-db = await Database.create("postgres", config)
+db = factory.create(backend="postgres", **config)
+await db.connect()
 ```
 
 ## Best Practices
 
 1. **Always close connections**: Use context managers or explicitly call `close()`:
    ```python
-   async with await Database.create("memory") as db:
-       # Use db
-       pass  # Auto-closes
+   from dataknobs_data import AsyncDatabaseFactory
+
+   # Using context manager (recommended)
+   factory = AsyncDatabaseFactory()
+   db = factory.create(backend="memory")
+
+   async with db:
+       # db is auto-connected and will auto-close
+       record = Record(data={"name": "Alice"})
+       await db.create(record)
+
+   # Or manually manage connections
+   db = factory.create(backend="memory")
+   await db.connect()
+   try:
+       await db.create(record)
+   finally:
+       await db.close()
    ```
 
 2. **Use type hints**: The package is fully typed for better IDE support:
    ```python
-   from dataknobs_data import Database, Record
-   
-   async def process_record(db: Database, id: str) -> Record | None:
-       return await db.read(id)
+   from dataknobs_data import AsyncDatabase, Record
+
+   async def process_record(db: AsyncDatabase, record_id: str) -> Record | None:
+       return await db.read(record_id)
    ```
 
 3. **Handle exceptions**: Catch specific exceptions for better error handling:

--- a/packages/data/docs/API_REFERENCE.md
+++ b/packages/data/docs/API_REFERENCE.md
@@ -374,7 +374,8 @@ The validation module (`dataknobs_data.validation`) provides schema-based valida
 Define validation schemas for your data.
 
 ```python
-from dataknobs_data.validation import Schema, FieldType
+from dataknobs_data import FieldType
+from dataknobs_data.validation import Schema
 from dataknobs_data.validation.constraints import Required, Range, Length, Pattern
 
 # Create schema
@@ -449,7 +450,8 @@ constraint = Length(min=10) | Pattern(r"^\d{5}$")  # OR
 Type coercion for automatic type conversion:
 
 ```python
-from dataknobs_data.validation import Coercer, FieldType
+from dataknobs_data import FieldType
+from dataknobs_data.validation import Coercer
 
 coercer = Coercer()
 


### PR DESCRIPTION
## What

The mkdocs **site** copy of the data API reference (`docs/packages/data/api-reference.md`) — the page a consumer reads first on the rendered docs — had drifted far behind the verified package-local source (`packages/data/docs/API_REFERENCE.md`) and taught API that does not exist in shipped `dataknobs-data`. This resyncs the site page to the verified source so the two differ only in one intra-doc link.

## Why it mattered

A consumer copy-pasting the rendered site quickstart hit an immediate `ImportError`/`AttributeError`. The fictional symbols the site taught:

| Site taught (fictional) | Verified against shipped code |
|---|---|
| `await Database.create("memory")` / `SyncDatabase.create(...)` — quickstart + all 7 backend examples | No `Database` class; construct via `DatabaseFactory().create(backend=…)` or typed `from_config` |
| `Any([...])` validation combinator | It is `AnyOf`; `Any` is not exported |
| `StreamConfig(buffer_size=1000)` | Fields are `batch_size` / `prefetch` / `timeout` / `on_error` |
| `database_factory("memory")` (called directly) | `database_factory` is a factory instance — `.create(backend=…)` |

Plus a stale "Enhanced Upsert (New)" section built on the fictional constructor, and missing real content (dot-notation, backend-comparison table, typed-config section) — all restored.

## Changes

- **`docs/packages/data/api-reference.md`** — reconciled to the verified source; now byte-identical except one intra-doc link. The source's single link points at the package-only Batch Processing Guide, which has no site page, so the site copy links to the migration guide instead (confirmed to cover the same streaming-write / `StreamConfig` / `StreamResult` / conflict-policy material). This is the one deliberate per-file delta, matching the "byte-identical modulo intra-doc links" shape of the already-clean pairs.
- **Both copies** — fixed a documentation-verification bug found while validating: the validation `Schema` and `Coercer` examples imported `FieldType` from `dataknobs_data.validation`, where it is not exported. It is a top-level `dataknobs_data` export; import it from there.

## Verification

- Every symbol the reconciled page teaches was executed against shipped `dataknobs_data` (no `Database` class, `AnyOf` not `Any`, no `StreamConfig.buffer_size`, factories not callable, typed-config path, corrected `FieldType` imports, CAS + `RetryExecutor`).
- Doc-only change; no code touched.
- `mkdocs build --strict` clean — the migration-guide link resolves in nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)