### PR TITLE
docs(data): fix fictional API in index + hybrid-search package docs

### DIFF
--- a/packages/data/docs/HYBRID_SEARCH.md
+++ b/packages/data/docs/HYBRID_SEARCH.md
@@ -235,9 +235,9 @@ async def hybrid_search(
 Uses native RRF retriever (Elasticsearch 8.8+):
 
 ```python
-from dataknobs_data.backends import ElasticsearchAsyncBackend
+from dataknobs_data.backends.elasticsearch_async import AsyncElasticsearchDatabase
 
-backend = ElasticsearchAsyncBackend(...)
+backend = AsyncElasticsearchDatabase(...)
 await backend.connect()
 
 # Native hybrid search using RRF retriever
@@ -260,9 +260,9 @@ results = await backend.hybrid_search(
 Uses tsvector + pgvector combination:
 
 ```python
-from dataknobs_data.backends import PostgresAsyncBackend
+from dataknobs_data.backends.postgres import AsyncPostgresDatabase
 
-backend = PostgresAsyncBackend(...)
+backend = AsyncPostgresDatabase(...)
 await backend.connect()
 
 # Hybrid search using tsvector and pgvector

--- a/packages/data/docs/index.md
+++ b/packages/data/docs/index.md
@@ -90,10 +90,11 @@ pip install "dataknobs-data[all]"
 ## Quick Start
 
 ```python
-from dataknobs_data import Database, Record, Query, Operator
+from dataknobs_data import AsyncDatabaseFactory, Record, Query, Operator
 
 # Create a database connection
-async with Database.create("memory") as db:
+factory = AsyncDatabaseFactory()
+async with factory.create(backend="memory") as db:
     # Create a record
     record = Record({
         "name": "Alice",
@@ -117,6 +118,8 @@ async with Database.create("memory") as db:
 |---------|---------|----------|-------------|
 | Memory | ✅ Stable | Testing, caching | Very High |
 | File | ✅ Stable | Local persistence | Medium |
+| SQLite | ✅ Stable | Embedded SQL, transactions | High |
+| DuckDB | ✅ Stable | Analytics, OLAP | High |
 | PostgreSQL | ✅ Stable | Relational data | High |
 | Elasticsearch | ✅ Stable | Search, analytics | High |
 | S3 | ✅ Stable | Cloud storage | Medium |


### PR DESCRIPTION
## Summary

Triage + fix of the drifted `dataknobs-data` documentation pairs. The
fictional API turned out to live in the **package-local sources** (the
nominally verified-correct side), not the rendered site mirrors — the opposite
of the prior api-reference fix.

Two package docs corrected (bug-fix-only, 9 insertions / 6 deletions):

- **`packages/data/docs/index.md`** — quickstart used a nonexistent `Database`
  class (`from dataknobs_data import Database` / `async with
  Database.create("memory")`). Replaced with the real
  `AsyncDatabaseFactory().create(backend="memory")` async-context pattern
  (verified end-to-end). The backend table was missing the shipped **SQLite**
  and **DuckDB** backends; both added.
- **`packages/data/docs/HYBRID_SEARCH.md`** — imported
  `ElasticsearchAsyncBackend` / `PostgresAsyncBackend` from
  `dataknobs_data.backends` (neither exists). Corrected to
  `AsyncElasticsearchDatabase` (`…backends.elasticsearch_async`) and
  `AsyncPostgresDatabase` (`…backends.postgres`), whose real `connect()` +
  `hybrid_search(query_text, query_vector, text_fields, k, config, …)` surface
  matches the examples.

## Triage of the other pairs (no change needed)

- **`grounded-sources`, `vector-filter-semantics`, `vector-timestamps`** —
  transclude their sources via mkdocs `--8<--` includes; drift is structurally
  impossible. The large diff-line counts were false positives from comparing a
  1–3 line include stub against the full source.
- **`pgvector-backend`** — legitimate content divergence; both trees are
  API-correct (`factory.create(backend="pgvector")`, real `PgVectorStore`
  methods). Left as an intentional divergence.
- **`index` / `hybrid-search`** — structural / condensation divergences; the
  bug fixes above are independent of the divergence.

Both edited files are GitHub-only sources not transcluded into the site, so the
mkdocs build is unaffected.

## Verification

Every corrected symbol executed against shipped `dataknobs_data`; async-context
quickstart run end-to-end; confirmed neither edited file is transcluded into the
site tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)