### PR TITLE
docs(data): mirror batch-processing guide to site; drop api-reference link exception

### DIFF
--- a/.dataknobs/docs-mirror-manifest.json
+++ b/.dataknobs/docs-mirror-manifest.json
@@ -14,20 +14,11 @@
       "site_dir": "docs/packages/data",
       "symlink": [
         {"package": "DEDUP.md", "site": "dedup.md"},
-        {"package": "KEYED_RECORD_STORE.md", "site": "keyed-record-store.md"}
+        {"package": "KEYED_RECORD_STORE.md", "site": "keyed-record-store.md"},
+        {"package": "BATCH_PROCESSING_GUIDE.md", "site": "batch-processing-guide.md"}
       ],
       "mirror": [
-        {
-          "package": "API_REFERENCE.md",
-          "site": "api-reference.md",
-          "line_exceptions": [
-            {
-              "package": "call. See the [Batch Processing Guide](BATCH_PROCESSING_GUIDE.md) for the",
-              "site": "call. See the [Migration guide](migration.md) for the",
-              "note": "The source links to BATCH_PROCESSING_GUIDE.md, which has no site mirror yet; the site repoints to the existing migration.md page (same streaming-write / StreamConfig material). Remove this exception once the batch guide is mirrored to the site."
-            }
-          ]
-        },
+        {"package": "API_REFERENCE.md", "site": "api-reference.md"},
         {"package": "TRANSACTIONS.md", "site": "transactions.md"}
       ],
       "transclude": [
@@ -42,7 +33,6 @@
       ],
       "package_only": [
         "ARCHITECTURE.md",
-        "BATCH_PROCESSING_GUIDE.md",
         "BOOLEAN_LOGIC_OPERATORS.md",
         "DESIGN_PLAN.md",
         "RECORD_ID_ARCHITECTURE.md",

--- a/docs/packages/data/api-reference.md
+++ b/docs/packages/data/api-reference.md
@@ -534,7 +534,7 @@ original = migration.apply(migrated, reverse=True)
 ### Migrator
 
 `Migrator` is a stateless orchestrator; the source and target are passed per
-call. See the [Migration guide](migration.md) for the
+call. See the [Batch Processing Guide](batch-processing-guide.md) for the
 streaming write path (`StreamConfig` / `StreamResult`) and the full
 conflict-policy API; `migrate_stream` / `migrate_parallel` / `migrate_async`
 are the streaming siblings of `migrate`.

--- a/docs/packages/data/batch-processing-guide.md
+++ b/docs/packages/data/batch-processing-guide.md
@@ -1,0 +1,1 @@
+../../../packages/data/docs/BATCH_PROCESSING_GUIDE.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
         - packages/data/hybrid-search.md
         - packages/data/dedup.md
         - packages/data/performance-tuning.md
+        - packages/data/batch-processing-guide.md
         - packages/data/migration.md
         - packages/data/validation.md
         - packages/data/pandas-integration.md


### PR DESCRIPTION
## What

Completes the `dataknobs-data` doc-mirror reconciliation by resolving the last unmirrored consumer-facing package doc: the **batch-processing guide** is now published to the mkdocs site.

- **`docs/packages/data/batch-processing-guide.md`** (new) — a **symlink** to its package source (`packages/data/docs/BATCH_PROCESSING_GUIDE.md`), the drift-proof mechanism already used for the link-free `dedup` / `keyed-record-store` mirrors. Added to the Data → Advanced Features nav.
- **`docs/packages/data/api-reference.md`** — with the guide now on the site, the earlier repoint reverts to the real target: `[Migration guide](migration.md)` → `[Batch Processing Guide](batch-processing-guide.md)`. This is now a plain filename delta the mirror guard canonicalizes automatically.
- **`.dataknobs/docs-mirror-manifest.json`** — reclassifies the guide `package_only` → `symlink` and removes the now-obsolete api-reference `line_exceptions` block.
- **`mkdocs.yml`** — one nav entry.

## Documentation verification

Because the guide is now user-facing, every symbol it teaches was verified against shipped `dataknobs_data`: `StreamConfig`/`StreamResult` fields (incl. `failed_indices` / `total_batches` / `skipped`), `ConflictPolicy`, `create_batch` / `upsert_batch`, `pandas.BatchConfig` / `ChunkedProcessor`, `streaming.StreamProcessor`, and the demonstrated call signatures — **all accurate; no source change needed**.

## Remaining package-only docs (by design)

The architecture / record-id / record-serialization overviews and the design plan are internal docs; the boolean-logic doc is an implementation record whose consumer content is already covered by the site's `query.md`. All stay `package_only` and are classified as such so the mirror guard accepts them without flagging.

## Verification

- `bin/docs-checks.sh` green — mkdocs `--strict` clean, versions in sync, **mirror guard: 11 classified pairs, all docs classified**
- `docs-mirror-check.py --fix` is a clean no-op (no spurious rewrites)
- Doc-only change; no code or behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)